### PR TITLE
Add sample VI1 certificate document

### DIFF
--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -1,0 +1,113 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    {
+      "uncefact": "https://edi3.org/vocabulary/uncefact/#",
+      "version": "http://www.w3.org/ns/odrl/2/version",
+      "TradeLineItem": {
+        "@id": "uncefact:TradeLineItem",
+        "@context": {
+          "@vocab": "https://edi3.org/vocabulary/uncefact/#",
+          "@propagate": true,
+          "@protected": true,
+          "parentConsignment": {
+              "@reverse": "includedConsignmentItem"
+          }
+        }
+      }
+    }
+  ],
+  "name": "VI1 Document for the Importation of wine into the European community",
+  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "issuer": { "id": "https://example.com", "name": "DEMO STORE" },
+  "type": ["VerifiableCredential", "VI1Credential"],
+  "credentialSubject": {
+      "@id": "example:wineTradeItem1",
+      "@type": "TradeLineItem",
+      "associatedDocument": {
+          "@type": "Document",
+          "issueDateTime": "2019-08-08T00:00:00Z",
+          "name": "VI1 Document for the Importation of wine into the European community",
+          "issuerAssignedIdentificationId": "A967733",
+          "issueLocation": {
+            "countryId": "AU",
+            "postalAddress": {
+                "streetName": "Cnr Hackney & Botanic roads",
+                "cityName": "Adelaide SA",
+                "postcodeCode": "5000"
+            }
+          },
+          "issuerParty": {
+            "@id": "https://www.agw.org.au/",
+            "name": "Australian Grape and Wine Authority Industry House"
+          }
+      },
+      "includedWithinConsignmentItem": {
+          "@id": "example:consignmentItem",
+          "@type": "ConsignmentItem",
+          "exportCountry": "unlocode:AU",
+          "parentConsignment": {
+            "@id": "example:consignment",
+            "@type": "Consignment",
+            "consigneeParty": {
+                "name": "Alliance Wine Co LTD",
+                "countryId": "unlocode:UK",
+                "postalAddress": {
+                    "streetName": "7 Beechfield Rd",
+                    "cityName": "Ayshire, Beith",
+                    "postcodeCode": "KA15 1LN"
+                }
+            },
+            "exporterParty": {
+                "name": "ALLIANCE WINE AUSTRALIA PTY LTD",
+                "countryId": "unlocode:AU",
+                "postalAddress": {
+                    "streetName": "160 May Terrace",
+                    "cityName": "Ottoway SA",
+                    "postcodeCode": "5013"
+                }
+            },
+            "unloadingLocation": {
+                "countryId": "UK",
+                "name": "Gnangemouth"
+            }
+        }
+    },
+    "specifiedProduct": {
+      "@id": "example:wineProduct1",
+      "@type": "Product",
+      "brandName": "Wine of Australia",
+      "applicableCharacteristic": [
+        {
+          "typeCode": "totalAlcoholicStrength",
+          "valueMeasure": 14.4
+        },
+        {
+          "typeCode": "totalAcidity",
+          "valueMeasure": 5.14
+        }
+      ]
+    }
+  },
+  "openAttestationMetadata": {
+    "template": {
+      "name": "CUSTOM_TEMPLATE",
+      "type": "EMBEDDED_RENDERER",
+      "url": "https://tutorial-renderer.openattestation.com"
+    },
+    "proof": {
+      "type": "OpenAttestationProofMethod",
+      "method": "DID",
+      "value": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+      "revocation": {
+        "type": "NONE"
+      }
+    },
+    "identityProof": {
+      "type": "DNS-DID",
+      "identifier": "example.tradetrust.io"
+    }
+  },
+  "attachments": [{ "fileName": "sample.pdf", "mimeType": "application/pdf", "data": "BASE64_ENCODED_FILE" }]
+}

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -20,8 +20,12 @@
   "name": "VI1 Document for the Importation of wine into the European community",
   "issuanceDate": "2010-01-01T19:23:24Z",
   "validFrom": "2010-01-01T19:23:24Z",
-  "issuer": { "id": "https://example.com", "name": "DEMO STORE" },
-  "type": ["VerifiableCredential", "VI1Credential"],
+  "issuer": {
+    "id": "https://example.com",
+    "@type": "OpenAttestationIssuer",
+    "name": "DEMO STORE"
+  },
+  "type": ["VerifiableCredential", "OpenAttestationCredential", "VI1Credential"],
   "credentialSubject": {
       "@id": "example:wineTradeItem1",
       "@type": "TradeLineItem",

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -91,6 +91,7 @@
       "brandName": "Wine of Australia",
       "description": "(12 x 750ml) Red 2019 South Australia Merlot",
       "actualQuantity": ["2520 l", "3360 bottles"],
+      "certificationEvidenceReferenceDocument": "https://www.agw.org.au/certificates/PSA16312",
       "applicableCharacteristic": [
         {
           "typeCode": "totalAlcoholicStrength",

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -11,6 +11,8 @@
           "@protected": true,
           "@vocab": "https://edi3.org/vocabulary/uncefact/#",
           "rec28": "https://edi3.org/vocabulary/rec28/#",
+          "qudt": "https://qudt.org/schema/qudt/",
+          "unit": "http://qudt.org/vocab/unit/",
           "parentConsignment": {
               "@reverse": "includedConsignmentItem"
           }
@@ -90,7 +92,12 @@
       "@type": "Product",
       "brandName": "Wine of Australia",
       "description": "(12 x 750ml) Red 2019 South Australia Merlot",
-      "actualQuantity": ["2520 l", "3360 bottles"],
+      "unitTypeCode": "bottle",
+      "contentUnitQuantity": 3360,
+      "qudt:hasQuantity": {
+        "qudt:unit": "unit:L",
+        "qudt:value": 2520.0
+      },
       "certificationEvidenceReferenceDocument": "https://www.agw.org.au/certificates/PSA16312",
       "applicableCharacteristic": [
         {

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -7,9 +7,10 @@
       "TradeLineItem": {
         "@id": "uncefact:TradeLineItem",
         "@context": {
-          "@vocab": "https://edi3.org/vocabulary/uncefact/#",
           "@propagate": true,
           "@protected": true,
+          "@vocab": "https://edi3.org/vocabulary/uncefact/#",
+          "rec28": "https://edi3.org/vocabulary/rec28/#",
           "parentConsignment": {
               "@reverse": "includedConsignmentItem"
           }
@@ -75,6 +76,12 @@
             "unloadingLocation": {
                 "countryId": "UK",
                 "name": "Gnangemouth"
+            },
+            "applicableTransportMeans": {
+                "@id": "https://maersk.com/vessels/123-456",
+                "@type": "TranstportMeans",
+                "transportMeansTypeCode": "rec28:General_cargo_vessel",
+                "name": "Ever Given"
             }
         }
     },

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -90,6 +90,7 @@
       "@type": "Product",
       "brandName": "Wine of Australia",
       "description": "(12 x 750ml) Red 2019 South Australia Merlot",
+      "actualQuantity": ["2520 l", "3360 bottles"],
       "applicableCharacteristic": [
         {
           "typeCode": "totalAlcoholicStrength",

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -89,6 +89,7 @@
       "@id": "example:wineProduct1",
       "@type": "Product",
       "brandName": "Wine of Australia",
+      "description": "(12 x 750ml) Red 2019 South Australia Merlot",
       "applicableCharacteristic": [
         {
           "typeCode": "totalAlcoholicStrength",

--- a/vi1-vc-sample.json
+++ b/vi1-vc-sample.json
@@ -99,6 +99,10 @@
         {
           "typeCode": "totalAcidity",
           "valueMeasure": 5.14
+        },
+        {
+          "typeCode": "totalSulphurDioxide",
+          "valueMeasure": 80.00
         }
       ]
     }


### PR DESCRIPTION
Sample uses UN/CEFACT vocabulary to describe verifiable credential certificate

- add vi1-vc-sample.json
- Add proper Openattestaion types
- add applicableTransportMeans to ConsignmentItem
- add Product description
- add Product actualQuantity
- add product total sulphur dioxide
- add product certificationEvidenceReferenceDocument
